### PR TITLE
feat: add auto scroll to new sections when created

### DIFF
--- a/src/course-outline/CourseOutline.jsx
+++ b/src/course-outline/CourseOutline.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { React, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import {
@@ -34,8 +34,10 @@ import ConfigureModal from './configure-modal/ConfigureModal';
 import DeleteModal from './delete-modal/DeleteModal';
 import { useCourseOutline } from './hooks';
 import messages from './messages';
+import { scrollToBottom } from './utils';
 
 const CourseOutline = ({ courseId }) => {
+  const listRef = useRef(null);
   const intl = useIntl();
 
   const {
@@ -76,6 +78,10 @@ const CourseOutline = ({ courseId }) => {
     handleDuplicateSectionSubmit,
     handleNewSectionSubmit,
   } = useCourseOutline({ courseId });
+
+  useEffect(() => {
+    scrollToBottom(listRef);
+  }, [sectionsList]);
 
   const {
     isShow: isShowProcessingNotification,
@@ -155,6 +161,7 @@ const CourseOutline = ({ courseId }) => {
                               onEditSectionSubmit={handleEditSectionSubmit}
                               onDuplicateSubmit={handleDuplicateSectionSubmit}
                               isSectionsExpanded={isSectionsExpanded}
+                              ref={listRef}
                             />
                           ))}
                           <Button

--- a/src/course-outline/CourseOutline.jsx
+++ b/src/course-outline/CourseOutline.jsx
@@ -34,7 +34,7 @@ import ConfigureModal from './configure-modal/ConfigureModal';
 import DeleteModal from './delete-modal/DeleteModal';
 import { useCourseOutline } from './hooks';
 import messages from './messages';
-import { scrollToBottom } from './utils';
+import { scrollToElement } from './utils';
 
 const CourseOutline = ({ courseId }) => {
   const listRef = useRef(null);
@@ -80,7 +80,7 @@ const CourseOutline = ({ courseId }) => {
   } = useCourseOutline({ courseId });
 
   useEffect(() => {
-    scrollToBottom(listRef);
+    scrollToElement(listRef);
   }, [sectionsList]);
 
   const {

--- a/src/course-outline/CourseOutline.test.jsx
+++ b/src/course-outline/CourseOutline.test.jsx
@@ -51,6 +51,8 @@ let store;
 const mockPathname = '/foo-bar';
 const courseId = '123';
 
+window.HTMLElement.prototype.scrollIntoView = jest.fn();
+
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useLocation: () => ({

--- a/src/course-outline/CourseOutline.test.jsx
+++ b/src/course-outline/CourseOutline.test.jsx
@@ -133,6 +133,7 @@ describe('<CourseOutline />', () => {
 
     element = await findAllByTestId('section-card');
     expect(element.length).toBe(5);
+    expect(window.HTMLElement.prototype.scrollIntoView).toBeCalled();
   });
 
   it('render error alert after failed reindex correctly', async () => {

--- a/src/course-outline/section-card/SectionCard.jsx
+++ b/src/course-outline/section-card/SectionCard.jsx
@@ -1,4 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import {
+  React,
+  forwardRef,
+  useEffect,
+  useState,
+} from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import { useIntl } from '@edx/frontend-platform/i18n';
@@ -11,7 +16,7 @@ import CardHeader from '../card-header/CardHeader';
 import { getSectionStatus } from '../utils';
 import messages from './messages';
 
-const SectionCard = ({
+const SectionCard = forwardRef(({
   section,
   children,
   onOpenHighlightsModal,
@@ -22,7 +27,7 @@ const SectionCard = ({
   onOpenDeleteModal,
   onDuplicateSubmit,
   isSectionsExpanded,
-}) => {
+}, lastItemRef) => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const [isExpanded, setIsExpanded] = useState(isSectionsExpanded);
@@ -80,7 +85,7 @@ const SectionCard = ({
   }, [savingStatus]);
 
   return (
-    <div className="section-card" data-testid="section-card">
+    <div className="section-card" data-testid="section-card" ref={lastItemRef}>
       <CardHeader
         sectionId={id}
         title={displayName}
@@ -130,7 +135,7 @@ const SectionCard = ({
       )}
     </div>
   );
-};
+});
 
 SectionCard.defaultProps = {
   children: null,

--- a/src/course-outline/utils.jsx
+++ b/src/course-outline/utils.jsx
@@ -109,8 +109,16 @@ const getHighlightsFormValues = (currentHighlights) => {
   return formValues;
 };
 
+/* eslint no-param-reassign: "error" */
+const scrollToBottom = (ref) => {
+  if (ref.current) {
+    ref.current.scrollIntoView({ behavior: 'smooth' });
+  }
+};
+
 export {
   getSectionStatus,
   getSectionStatusBadgeContent,
   getHighlightsFormValues,
+  scrollToBottom,
 };

--- a/src/course-outline/utils.jsx
+++ b/src/course-outline/utils.jsx
@@ -109,16 +109,13 @@ const getHighlightsFormValues = (currentHighlights) => {
   return formValues;
 };
 
-/* eslint no-param-reassign: "error" */
-const scrollToBottom = (ref) => {
-  if (ref.current) {
-    ref.current.scrollIntoView({ behavior: 'smooth' });
-  }
+const scrollToElement = (ref) => {
+  ref.current?.scrollIntoView({ behavior: 'smooth' });
 };
 
 export {
   getSectionStatus,
   getSectionStatusBadgeContent,
   getHighlightsFormValues,
-  scrollToBottom,
+  scrollToElement,
 };


### PR DESCRIPTION
Resolves `Private-ref`: https://tasks.opencraft.com/browse/BB-8220

This PR,

- Creates a generic scroll to reference function under `utils.jsx`
- Adds an effect for when the list is changed
- Adds the reference to scroll to the last `SectionCard` item


https://github.com/open-craft/frontend-app-course-authoring/assets/20992645/33fd0a69-09fb-46cd-99bf-7e673f72147f


**Depends on**

- https://github.com/open-craft/frontend-app-course-authoring/pull/12

**Testing instructions**

- Follow instructions from the readme
- Checkout branch from https://github.com/openedx/edx-platform/pull/33667 and run `make cms-up` in devstack.
- Open any course outline by using this url format: http://localhost:2001/course/course-v1:edX+DemoX+Demo_Course/outline
- Click any of the `new section` buttons available in the outline