### PR TITLE
feat: Add clear filter btn to filter widget

### DIFF
--- a/src/search-manager/FilterBy.scss
+++ b/src/search-manager/FilterBy.scss
@@ -5,3 +5,7 @@
     width: 100%;
   }
 }
+
+.clear-filter-button:hover {
+  color: $info-900 !important;
+}

--- a/src/search-manager/FilterByBlockType.tsx
+++ b/src/search-manager/FilterByBlockType.tsx
@@ -70,9 +70,10 @@ const FilterByBlockType: React.FC<Record<never, never>> = () => {
     <SearchFilterWidget
       appliedFilters={blockTypesFilter.map(blockType => ({ label: <BlockTypeLabel type={blockType} /> }))}
       label={<FormattedMessage {...messages.blockTypeFilter} />}
+      clearFilter={() => setBlockTypesFilter([])}
       icon={FilterList}
     >
-      <Form.Group>
+      <Form.Group className="mb-0">
         <Form.CheckboxSet
           name="block-type-filter"
           defaultValue={blockTypesFilter}

--- a/src/search-manager/FilterByTags.tsx
+++ b/src/search-manager/FilterByTags.tsx
@@ -168,7 +168,7 @@ const TagOptions: React.FC<{
 
 const FilterByTags: React.FC<Record<never, never>> = () => {
   const intl = useIntl();
-  const { tagsFilter } = useSearchContext();
+  const { tagsFilter, setTagsFilter } = useSearchContext();
   const [tagSearchKeywords, setTagSearchKeywords] = React.useState('');
 
   // e.g. {"Location", "Location > North America"} if those two paths of the tag tree are expanded
@@ -186,9 +186,10 @@ const FilterByTags: React.FC<Record<never, never>> = () => {
     <SearchFilterWidget
       appliedFilters={tagsFilter.map(tf => ({ label: tf.split(TAG_SEP).pop() }))}
       label={<FormattedMessage {...messages.blockTagsFilter} />}
+      clearFilter={() => setTagsFilter([])}
       icon={Tag}
     >
-      <Form.Group className="pt-3">
+      <Form.Group className="pt-3 mb-0">
         <SearchField
           onSubmit={setTagSearchKeywords}
           onChange={setTagSearchKeywords}

--- a/src/search-manager/SearchFilterWidget.tsx
+++ b/src/search-manager/SearchFilterWidget.tsx
@@ -6,6 +6,9 @@ import {
   ModalPopup,
   useToggle,
 } from '@openedx/paragon';
+import { useIntl } from '@edx/frontend-platform/i18n';
+
+import messages from './messages';
 
 /**
  * A button that represents a filter on the search.
@@ -22,10 +25,17 @@ const SearchFilterWidget: React.FC<{
   appliedFilters: { label: React.ReactNode }[];
   label: React.ReactNode;
   children: React.ReactNode;
+  clearFilter: () => void,
   icon?: React.ReactNode; // eslint-disable-line react/require-default-props
 }> = ({ appliedFilters, ...props }) => {
+  const intl = useIntl();
   const [isOpen, open, close] = useToggle(false);
   const [target, setTarget] = React.useState(null);
+
+  const clearAndClose = React.useCallback(() => {
+    props.clearFilter();
+    close();
+  }, [props.clearFilter]);
 
   return (
     <>
@@ -53,6 +63,21 @@ const SearchFilterWidget: React.FC<{
           style={{ textAlign: 'start' }}
         >
           {props.children}
+
+          {
+            !!appliedFilters.length
+            && (
+              <div className="d-flex justify-content-end">
+                <Button
+                  onClick={clearAndClose}
+                  variant="link"
+                  className="text-info-500 text-decoration-none clear-filter-button"
+                >
+                  { intl.formatMessage(messages.clearFilter) }
+                </Button>
+              </div>
+            )
+          }
         </div>
       </ModalPopup>
     </>

--- a/src/search-manager/messages.ts
+++ b/src/search-manager/messages.ts
@@ -70,6 +70,11 @@ const messages = defineMessages({
     defaultMessage: '{numResults, plural, one {# result} other {# results}} found',
     description: 'This count displays how many matching results were found from the user\'s search',
   },
+  clearFilter: {
+    id: 'course-authoring.search-manager.searchFilterWidget.clearFilter',
+    defaultMessage: 'Clear Filter',
+    description: 'Label for the button that removes applied search filters in a specific widget',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
## Description

This PR adds the ability to clear a specific filter through a "Clear Filter" button in the widget, leaving the applied filters in other widgets unchanged.

<img width="717" alt="Screenshot 2024-07-03 at 5 23 13 PM" src="https://github.com/open-craft/frontend-app-course-authoring/assets/6829768/c6090b8a-404c-457b-be54-8026eda7c2ab">

## Supporting Information
- Related Issue: https://github.com/openedx/frontend-app-course-authoring/issues/1048

## Testing Instructions
1. Run this branch in your local env
1. Navigate to a Content Library you already have (make sure you have a few components in that Content Library, ideally in different types)
1. Make sure you have some tags applied to those components
1. Confirm that the "Filter Tags" buttons appears at the bottom of the dropdown after applying a filter (similar to screenshot above)
1. Confirm that clearing filters in one widget does **not** clear the applied filters in the other widget 

---
Private-ref: [FAL-3763](https://tasks.opencraft.com/browse/FAL-3763)