### PR TITLE
feat: persist discussion alert dismissal

### DIFF
--- a/src/course-outline/page-alerts/PageAlerts.jsx
+++ b/src/course-outline/page-alerts/PageAlerts.jsx
@@ -41,8 +41,11 @@ const PageAlerts = ({
   const intl = useIntl();
   const dispatch = useDispatch();
   const studioBaseUrl = getConfig().STUDIO_BASE_URL;
+  const discussionAlertDismissKey = `discussionAlertDismissed-${courseId}`;
   const [showConfigAlert, setShowConfigAlert] = useState(true);
-  const [showDiscussionAlert, setShowDiscussionAlert] = useState(true);
+  const [showDiscussionAlert, setShowDiscussionAlert] = useState(
+    localStorage.getItem(discussionAlertDismissKey) === null,
+  );
   const { newFiles, conflictingFiles, errorFiles } = useSelector(getPasteFileNotices);
 
   const getAssetsUrl = () => {
@@ -83,6 +86,7 @@ const PageAlerts = ({
 
     const onDismiss = () => {
       setShowDiscussionAlert(false);
+      localStorage.setItem(discussionAlertDismissKey, 'true');
     };
 
     return (

--- a/src/course-outline/page-alerts/PageAlerts.test.jsx
+++ b/src/course-outline/page-alerts/PageAlerts.test.jsx
@@ -98,6 +98,11 @@ describe('<PageAlerts />', () => {
     expect(learnMoreBtn).toBeInTheDocument();
     expect(learnMoreBtn).toHaveAttribute('href', 'some-learn-more-url');
 
+    const dismissBtn = queryByText('Dismiss');
+    await act(async () => fireEvent.click(dismissBtn));
+    const discussionAlertDismissKey = `discussionAlertDismissed-${pageAlertsData.courseId}`;
+    expect(localStorage.getItem(discussionAlertDismissKey)).toBe('true');
+
     const feedbackLink = queryByText(messages.discussionNotificationFeedback.defaultMessage);
     expect(feedbackLink).toBeInTheDocument();
     expect(feedbackLink).toHaveAttribute('href', 'some-feedback-url');


### PR DESCRIPTION
# Description
The alert used to inform about the usage of an upgraded version of discussion forum still shows on refresh after being dismissed.  The goal of this PR is correct that and save the dismissal per course.

# Testing instruction
- Clone this repository and run `npm insall`
- Ensure your are running Tutor redwood locally (>= 18)
- Mount the clone repository to Tutor using `tutor mounts add  your/path/to/frontend-app-course-authoring`
- Run `tutor dev launch`
- To simplify testing and show the Alert, comment out the following or set the condition to be always false.
 ```
if (providerType !== 'openedx') {
      return null;
    }
```
- Dismiss the Alert then refresh. The alert will show again
- Checkout this PR's branch then run `npm install`
- Now after dismissal and refresh, the alert shouldn't show.

#  ref
BB-9079