### PR TITLE
fix: update prereq state for all

### DIFF
--- a/src/course-outline/hooks.jsx
+++ b/src/course-outline/hooks.jsx
@@ -187,7 +187,9 @@ const useCourseOutline = ({ courseId }) => {
       dispatch(configureCourseSectionQuery(currentSection.id, ...arg));
       break;
     case COURSE_BLOCK_NAMES.sequential.id:
-      dispatch(configureCourseSubsectionQuery(currentItem.id, currentSection.id, ...arg));
+      dispatch(configureCourseSubsectionQuery(currentItem.id, currentSection.id, ...arg)).then(() => {
+          dispatch(fetchCourseOutlineIndexQuery(courseId));
+        });
       break;
     case COURSE_BLOCK_NAMES.vertical.id:
       dispatch(configureCourseUnitQuery(currentItem.id, currentSection.id, ...arg));


### PR DESCRIPTION
Prerequisites don't update for all sections when a subsection is set as prerequisite, only for its own section. This is because the prerequisites list is part of the state of each configure modal instead of the global state. Because of this, when prerequisites change (and sections), the whole course outline state needs to be reloaded.

Here's a video of the issue:

[Screencast from 09-03-2024 05:51:58 PM.webm](https://github.com/user-attachments/assets/e6159a54-b50d-443d-ba85-17e15cc3e7e8)


# Testing instructions

## 0. setup tutor

- If you have tvm you can use it: `tvm project init tutor-eshe v18.1.3 && cd tutor-eshe && source .tvm/bin/activate`
- Add a plugin to config MFE. Create the file inside `tutor-eshe/plugins/mfe_config.yml` and th
```
name: mfe_config
version: 0.1.0
patches:
  mfe-lms-common-settings: |
    MFE_CONFIG.update({
        "PARAGON_THEME_URLS": {
            "core": {
                "urls": {
                    "default": "https://cdn.jsdelivr.net/npm/@openedx/paragon@23.0.0-alpha.1/dist/core.min.css",
                    "brandOverride": "https://cdn.jsdelivr.net/npm/@edx/brand-edx.org@2.2.0-alpha.17/dist/core.min.css"
                }
            },
            "variants": {
                "light": {
                    "urls": {
                        "default": "https://cdn.jsdelivr.net/npm/@openedx/paragon@23.0.0-alpha.1/dist/light.min.css",
                        "brandOverride": "https://eshe-themes-static-files.s3.me-south-1.amazonaws.com/css/core.min.css"
                    },
                    "default": True,
                    "dark": False
                }
            }
        }
    })
```
- And then install all required plugins
```
tutor plugins update && tutor plugins install mfe && tutor plugins enable mfe_config
```
- Clone this branch and add to the mounts with `tutor mounts add frontend-app-course-authoring`
- Start the instance with `tutor dev launch`
- Import the demo course with `tutor dev do importdemocourse`
- Create a staff user with `tutor dev do createuser --staff --superuser staff staff@example.com -p staff`


##  Test
- Login and go to the demo course in studio
- For any subsection, in the advanced tab, check the box for letting the subsection be a prerequisite
- After it's saved, check the advanced tab for a subsection __from another section__, and assert that in the dropdown for selecting prerequisites, the subsection from the previous step appears.

Fixes: #1328