### PR TITLE
feat: Add support for toggling more parts of the progress page on or off

### DIFF
--- a/src/pages-and-resources/progress/Settings.jsx
+++ b/src/pages-and-resources/progress/Settings.jsx
@@ -1,19 +1,32 @@
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { getConfig } from '@edx/frontend-platform';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import PropTypes from 'prop-types';
 import React from 'react';
 import * as Yup from 'yup';
-import { getConfig } from '@edx/frontend-platform';
+import messages from './messages';
 import FormSwitchGroup from '../../generic/FormSwitchGroup';
 import { useAppSetting } from '../../utils';
 import AppSettingsModal from '../app-settings-modal/AppSettingsModal';
-import messages from './messages';
 
-const ProgressSettings = ({ intl, onClose }) => {
+const ProgressSettings = ({ onClose }) => {
+  const intl = useIntl();
   const [disableProgressGraph, saveSetting] = useAppSetting('disableProgressGraph');
-  const showProgressGraphSetting = getConfig().ENABLE_PROGRESS_GRAPH_SETTINGS.toLowerCase() === 'true';
+  const [otherCourseSettings, saveOtherCourseSettings] = useAppSetting('otherCourseSettings');
+  const showProgressGraphSetting = getConfig().ENABLE_PROGRESS_GRAPH_SETTINGS.toString().toLowerCase() === 'true';
 
-  const handleSettingsSave = (values) => {
-    if (showProgressGraphSetting) { saveSetting(!values.enableProgressGraph); }
+  const handleSettingsSave = async (values) => {
+    if (showProgressGraphSetting) {
+      await saveSetting(!values.enableProgressGraph);
+    }
+    const updatedOtherCourseSettings = {
+      ...otherCourseSettings,
+      progressPage: {
+        showGrades: values.showGrades,
+        showGradeSummary: values.showGradeSummary,
+        showRelatedLinks: values.showRelatedLinks,
+      },
+    };
+    await saveOtherCourseSettings(updatedOtherCourseSettings);
   };
 
   return (
@@ -24,23 +37,62 @@ const ProgressSettings = ({ intl, onClose }) => {
       enableAppLabel={intl.formatMessage(messages.enableProgressLabel)}
       learnMoreText={intl.formatMessage(messages.enableProgressLink)}
       onClose={onClose}
-      initialValues={{ enableProgressGraph: !disableProgressGraph }}
-      validationSchema={{ enableProgressGraph: Yup.boolean() }}
+      initialValues={{
+        enableProgressGraph: !disableProgressGraph,
+        showGrades: !!otherCourseSettings?.progressPage?.showGrades,
+        showGradeSummary: !!otherCourseSettings?.progressPage?.showGradeSummary,
+        showRelatedLinks: !!otherCourseSettings?.progressPage?.showRelatedLinks,
+      }}
+      validationSchema={{
+        enableProgressGraph: Yup.boolean(),
+        showGrades: Yup.boolean(),
+        showGradeSummary: Yup.boolean(),
+        showRelatedLinks: Yup.boolean(),
+      }}
       onSettingsSave={handleSettingsSave}
     >
       {
         ({ handleChange, handleBlur, values }) => (
-          showProgressGraphSetting && (
-          <FormSwitchGroup
-            id="enable-progress-graph"
-            name="enableProgressGraph"
-            label={intl.formatMessage(messages.enableGraphLabel)}
-            helpText={intl.formatMessage(messages.enableGraphHelp)}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            checked={values.enableProgressGraph}
-          />
-          )
+          <>
+            {showProgressGraphSetting && (
+              <FormSwitchGroup
+                id="enable-progress-graph"
+                name="enableProgressGraph"
+                label={intl.formatMessage(messages.enableGraphLabel)}
+                helpText={intl.formatMessage(messages.enableGraphHelp)}
+                onChange={handleChange}
+                onBlur={handleBlur}
+                checked={values.enableProgressGraph}
+              />
+            )}
+            <FormSwitchGroup
+              id="show-grades"
+              name="showGrades"
+              label={intl.formatMessage(messages.showGradesLabel)}
+              helpText={intl.formatMessage(messages.showGradesHelp)}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              checked={values.showGrades}
+            />
+            <FormSwitchGroup
+              id="show-grade-summary"
+              name="showGradeSummary"
+              label={intl.formatMessage(messages.showGradeSummaryLabel)}
+              helpText={intl.formatMessage(messages.showGradeSummaryHelp)}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              checked={values.showGradeSummary}
+            />
+            <FormSwitchGroup
+              id="show-related-links"
+              name="showRelatedLinks"
+              label={intl.formatMessage(messages.showRelatedLinksLabel)}
+              helpText={intl.formatMessage(messages.showRelatedLinksHelp)}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              checked={values.showRelatedLinks}
+            />
+          </>
         )
       }
     </AppSettingsModal>
@@ -48,8 +100,7 @@ const ProgressSettings = ({ intl, onClose }) => {
 };
 
 ProgressSettings.propTypes = {
-  intl: intlShape.isRequired,
   onClose: PropTypes.func.isRequired,
 };
 
-export default injectIntl(ProgressSettings);
+export default ProgressSettings;

--- a/src/pages-and-resources/progress/Settings.jsx
+++ b/src/pages-and-resources/progress/Settings.jsx
@@ -22,8 +22,9 @@ const ProgressSettings = ({ onClose }) => {
       ...otherCourseSettings,
       progressPage: {
         showGrades: values.showGrades,
-        showGradeSummary: values.showGradeSummary,
+        showGradeBreakdown: values.showGradeBreakdown,
         showRelatedLinks: values.showRelatedLinks,
+        showCertificateStatus: values.showCertificateStatus,
       },
     };
     await saveOtherCourseSettings(updatedOtherCourseSettings);
@@ -39,15 +40,17 @@ const ProgressSettings = ({ onClose }) => {
       onClose={onClose}
       initialValues={{
         enableProgressGraph: !disableProgressGraph,
-        showGrades: !!otherCourseSettings?.progressPage?.showGrades,
-        showGradeSummary: !!otherCourseSettings?.progressPage?.showGradeSummary,
-        showRelatedLinks: !!otherCourseSettings?.progressPage?.showRelatedLinks,
+        showGrades: otherCourseSettings?.progressPage?.showGrades ?? true,
+        showGradeBreakdown: otherCourseSettings?.progressPage?.showGradeBreakdown ?? true,
+        showRelatedLinks: otherCourseSettings?.progressPage?.showRelatedLinks ?? true,
+        showCertificateStatus: otherCourseSettings?.progressPage?.showCertificateStatus ?? true,
       }}
       validationSchema={{
         enableProgressGraph: Yup.boolean(),
         showGrades: Yup.boolean(),
-        showGradeSummary: Yup.boolean(),
+        showGradeBreakdown: Yup.boolean(),
         showRelatedLinks: Yup.boolean(),
+        showCertificateStatus: Yup.boolean(),
       }}
       onSettingsSave={handleSettingsSave}
     >
@@ -75,13 +78,13 @@ const ProgressSettings = ({ onClose }) => {
               checked={values.showGrades}
             />
             <FormSwitchGroup
-              id="show-grade-summary"
-              name="showGradeSummary"
-              label={intl.formatMessage(messages.showGradeSummaryLabel)}
-              helpText={intl.formatMessage(messages.showGradeSummaryHelp)}
+              id="show-grade-breakdown"
+              name="showGradeBreakdown"
+              label={intl.formatMessage(messages.showGradeBreakdownLabel)}
+              helpText={intl.formatMessage(messages.showGradeBreakdownHelp)}
               onChange={handleChange}
               onBlur={handleBlur}
-              checked={values.showGradeSummary}
+              checked={values.showGradeBreakdown}
             />
             <FormSwitchGroup
               id="show-related-links"
@@ -91,6 +94,15 @@ const ProgressSettings = ({ onClose }) => {
               onChange={handleChange}
               onBlur={handleBlur}
               checked={values.showRelatedLinks}
+            />
+            <FormSwitchGroup
+              id="show-certificate-status"
+              name="showCertificateStatus"
+              label={intl.formatMessage(messages.showCertificateStatusLabel)}
+              helpText={intl.formatMessage(messages.showCertificateStatusHelp)}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              checked={values.showCertificateStatus}
             />
           </>
         )

--- a/src/pages-and-resources/progress/Settings.jsx
+++ b/src/pages-and-resources/progress/Settings.jsx
@@ -22,7 +22,8 @@ const ProgressSettings = ({ onClose }) => {
       ...otherCourseSettings,
       progressPage: {
         showGrades: values.showGrades,
-        showGradeBreakdown: values.showGradeBreakdown,
+        showGradeSummary: values.showGradeSummary,
+        showGradeDetails: values.showGradeDetails,
         showRelatedLinks: values.showRelatedLinks,
         showCertificateStatus: values.showCertificateStatus,
       },
@@ -41,14 +42,16 @@ const ProgressSettings = ({ onClose }) => {
       initialValues={{
         enableProgressGraph: !disableProgressGraph,
         showGrades: otherCourseSettings?.progressPage?.showGrades ?? true,
-        showGradeBreakdown: otherCourseSettings?.progressPage?.showGradeBreakdown ?? true,
+        showGradeSummary: otherCourseSettings?.progressPage?.showGradeSummary ?? true,
+        showGradeDetails: otherCourseSettings?.progressPage?.showGradeDetails ?? true,
         showRelatedLinks: otherCourseSettings?.progressPage?.showRelatedLinks ?? true,
         showCertificateStatus: otherCourseSettings?.progressPage?.showCertificateStatus ?? true,
       }}
       validationSchema={{
         enableProgressGraph: Yup.boolean(),
         showGrades: Yup.boolean(),
-        showGradeBreakdown: Yup.boolean(),
+        showGradeSummary: Yup.boolean(),
+        showGradeDetails: Yup.boolean(),
         showRelatedLinks: Yup.boolean(),
         showCertificateStatus: Yup.boolean(),
       }}
@@ -78,13 +81,22 @@ const ProgressSettings = ({ onClose }) => {
               checked={values.showGrades}
             />
             <FormSwitchGroup
-              id="show-grade-breakdown"
-              name="showGradeBreakdown"
-              label={intl.formatMessage(messages.showGradeBreakdownLabel)}
-              helpText={intl.formatMessage(messages.showGradeBreakdownHelp)}
+              id="show-grade-summary"
+              name="showGradeSummary"
+              label={intl.formatMessage(messages.showGradeSummaryLabel)}
+              helpText={intl.formatMessage(messages.showGradeSummaryHelp)}
               onChange={handleChange}
               onBlur={handleBlur}
-              checked={values.showGradeBreakdown}
+              checked={values.showGradeSummary}
+            />
+            <FormSwitchGroup
+              id="show-grade-details"
+              name="showGradeDetails"
+              label={intl.formatMessage(messages.showGradeDetailsLabel)}
+              helpText={intl.formatMessage(messages.showGradeDetailsHelp)}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              checked={values.showGradeDetails}
             />
             <FormSwitchGroup
               id="show-related-links"

--- a/src/pages-and-resources/progress/messages.js
+++ b/src/pages-and-resources/progress/messages.js
@@ -36,13 +36,13 @@ const messages = defineMessages({
     id: 'course-authoring.pages-resources.progress.show-grades.help',
     defaultMessage: 'If enabled, students can see their grades on the progress page.',
   },
-  showGradeSummaryLabel: {
-    id: 'course-authoring.pages-resources.progress.show-grade-summary.label',
-    defaultMessage: 'Show grades Summary',
+  showGradeBreakdownLabel: {
+    id: 'course-authoring.pages-resources.progress.show-grade-breakdown.label',
+    defaultMessage: 'Show Grade Breakdown',
   },
-  showGradeSummaryHelp: {
-    id: 'course-authoring.pages-resources.progress.show-grade-summary.help',
-    defaultMessage: 'If enabled, students can see a summary of their grades on the progress page.',
+  showGradeBreakdownHelp: {
+    id: 'course-authoring.pages-resources.progress.show-grade-breakdown.help',
+    defaultMessage: 'If enabled, students can see a summary and detailed breakdown of their grades on the progress page.',
   },
   showRelatedLinksLabel: {
     id: 'course-authoring.pages-resources.progress.show-related-links.label',
@@ -51,6 +51,14 @@ const messages = defineMessages({
   showRelatedLinksHelp: {
     id: 'course-authoring.pages-resources.progress.show-related-links.help',
     defaultMessage: 'If enabled, students can see related links in the sidebar on the progress page.',
+  },
+  showCertificateStatusLabel: {
+    id: 'course-authoring.pages-resources.progress.show-certificate-status.label',
+    defaultMessage: 'Show Certificate Status',
+  },
+  showCertificateStatusHelp: {
+    id: 'course-authoring.pages-resources.progress.show-certificate-status.help',
+    defaultMessage: 'If enabled, students can see the status of their certificates on the progress page.',
   },
 });
 

--- a/src/pages-and-resources/progress/messages.js
+++ b/src/pages-and-resources/progress/messages.js
@@ -28,6 +28,30 @@ const messages = defineMessages({
     id: 'course-authoring.pages-resources.progress.enable-graph.help',
     defaultMessage: 'If enabled, students can view the progress graph',
   },
+  showGradesLabel: {
+    id: 'course-authoring.pages-resources.progress.show-grades.label',
+    defaultMessage: 'Show grades',
+  },
+  showGradesHelp: {
+    id: 'course-authoring.pages-resources.progress.show-grades.help',
+    defaultMessage: 'If enabled, students can see their grades on the progress page.',
+  },
+  showGradeSummaryLabel: {
+    id: 'course-authoring.pages-resources.progress.show-grade-summary.label',
+    defaultMessage: 'Show grades Summary',
+  },
+  showGradeSummaryHelp: {
+    id: 'course-authoring.pages-resources.progress.show-grade-summary.help',
+    defaultMessage: 'If enabled, students can see a summary of their grades on the progress page.',
+  },
+  showRelatedLinksLabel: {
+    id: 'course-authoring.pages-resources.progress.show-related-links.label',
+    defaultMessage: 'Show Related Links',
+  },
+  showRelatedLinksHelp: {
+    id: 'course-authoring.pages-resources.progress.show-related-links.help',
+    defaultMessage: 'If enabled, students can see related links in the sidebar on the progress page.',
+  },
 });
 
 export default messages;

--- a/src/pages-and-resources/progress/messages.js
+++ b/src/pages-and-resources/progress/messages.js
@@ -36,13 +36,21 @@ const messages = defineMessages({
     id: 'course-authoring.pages-resources.progress.show-grades.help',
     defaultMessage: 'If enabled, students can see their grades on the progress page.',
   },
-  showGradeBreakdownLabel: {
-    id: 'course-authoring.pages-resources.progress.show-grade-breakdown.label',
-    defaultMessage: 'Show Grade Breakdown',
+  showGradeSummaryLabel: {
+    id: 'course-authoring.pages-resources.progress.show-grade-summary.label',
+    defaultMessage: 'Show Grade Summary',
   },
-  showGradeBreakdownHelp: {
-    id: 'course-authoring.pages-resources.progress.show-grade-breakdown.help',
-    defaultMessage: 'If enabled, students can see a summary and detailed breakdown of their grades on the progress page.',
+  showGradeSummaryHelp: {
+    id: 'course-authoring.pages-resources.progress.show-grade-summary.help',
+    defaultMessage: 'If enabled, students can see a summary of their grades on the progress page.',
+  },
+  showGradeDetailsLabel: {
+    id: 'course-authoring.pages-resources.progress.show-grade-details.label',
+    defaultMessage: 'Show Grade Details',
+  },
+  showGradeDetailsHelp: {
+    id: 'course-authoring.pages-resources.progress.show-grade-details.help',
+    defaultMessage: 'If enabled, students can see details of their grades on the progress page.',
   },
   showRelatedLinksLabel: {
     id: 'course-authoring.pages-resources.progress.show-related-links.label',


### PR DESCRIPTION
This PR adds toggles to the progress page for showing and hiding components in the progress tab. 

It works in conjunction with https://github.com/open-craft/frontend-app-learning/pull/36 which actually applies the changes. 

Private-ref: [BB-9200](https://tasks.opencraft.com/browse/BB-9200)