### PR TITLE
Fixes the saving pop-up to appear

### DIFF
--- a/src/grading-settings/grading-scale/GradingScale.jsx
+++ b/src/grading-settings/grading-scale/GradingScale.jsx
@@ -55,40 +55,44 @@ const GradingScale = ({
   }, [gradingSegments, letters]);
 
   const addNewGradingSegment = () => {
-    setGradingSegments(prevSegments => {
+    setGradingSegments((prevSegments) => {
+      let updatedGradingSegment = [];
       if (prevSegments.length >= 5) {
         const segSize = MAXIMUM_SCALE_LENGTH / (prevSegments.length + 1);
-        return Array.from({ length: prevSegments.length + 1 }).map((_, i) => (
-          {
-            current: 100 - i * segSize,
-            previous: 100 - (i + 1) * segSize,
-          }
-        ));
+        updatedGradingSegment = Array.from({
+          length: prevSegments.length + 1,
+        }).map((_, i) => ({
+          current: 100 - i * segSize,
+          previous: 100 - (i + 1) * segSize,
+        }));
+      } else {
+        const firstSegment = prevSegments[prevSegments.length - 1];
+        const secondSegment = prevSegments[prevSegments.length - 2];
+        const newCurrentValue = Math.ceil(
+          (secondSegment.current - secondSegment.previous) / 2,
+        );
+
+        const newSegment = {
+          current: firstSegment.current + newCurrentValue,
+          previous: firstSegment.current,
+        };
+
+        const updatedSecondSegment = {
+          ...secondSegment,
+          previous: firstSegment.current + newCurrentValue,
+        };
+        updatedGradingSegment = [
+          ...prevSegments.slice(0, prevSegments.length - 2),
+          updatedSecondSegment,
+          newSegment,
+          firstSegment,
+        ];
       }
-      const firstSegment = prevSegments[prevSegments.length - 1];
-      const secondSegment = prevSegments[prevSegments.length - 2];
-      const newCurrentValue = Math.ceil((secondSegment.current - secondSegment.previous) / 2);
-
-      const newSegment = {
-        current: (firstSegment.current + newCurrentValue),
-        previous: firstSegment.current,
-      };
-
-      const updatedSecondSegment = {
-        ...secondSegment,
-        previous: (firstSegment.current + newCurrentValue),
-      };
 
       showSavePrompt(true);
       setShowSuccessAlert(false);
       setOverrideInternetConnectionAlert(false);
-
-      return [
-        ...prevSegments.slice(0, prevSegments.length - 2),
-        updatedSecondSegment,
-        newSegment,
-        firstSegment,
-      ];
+      return updatedGradingSegment;
     });
 
     const nextIndex = (letters.length % defaultGradeDesignations.length);

--- a/src/grading-settings/grading-scale/GradingScale.test.jsx
+++ b/src/grading-settings/grading-scale/GradingScale.test.jsx
@@ -123,4 +123,33 @@ describe('<GradingScale />', () => {
       expect(segmentInputs[1]).toHaveValue('Test');
     });
   });
+
+  it('should render GradingScale component with more than 5 grades', async () => {
+    const { getAllByTestId } = render(
+      <IntlProvider locale="en" messages={{}}>
+        <GradingScale
+          intl={injectIntl}
+          gradeCutoffs={gradeCutoffs}
+          gradeLetters={gradeLetters}
+          sortedGrades={sortedGrades}
+          resetDataRef={{ current: false }}
+          showSavePrompt={jest.fn()}
+          setShowSuccessAlert={jest.fn()}
+          setGradingData={jest.fn()}
+          setOverrideInternetConnectionAlert={jest.fn()}
+          setEligibleGrade={jest.fn()}
+          defaultGradeDesignations={['A', 'B', 'C', 'D', 'E']}
+        />
+      </IntlProvider>,
+    );
+    await waitFor(() => {
+      const addNewSegmentBtn = getAllByTestId('grading-scale-btn-add-segment');
+      expect(addNewSegmentBtn[0]).toBeInTheDocument();
+      fireEvent.click(addNewSegmentBtn[0]);
+      const segments = getAllByTestId('grading-scale-segment-number');
+      // Calculation is based on 100/6 i.e A, B, C, D, E, F which comes to 16.666666666666657
+      expect(segments[0].textContent).toEqual('83.33333333333333 - 100');
+      expect(segments[6].textContent).toEqual('0 - 15.666666666666657');
+    });
+  });
 });

--- a/src/grading-settings/grading-scale/components/GradingScaleSegment.jsx
+++ b/src/grading-settings/grading-scale/components/GradingScaleSegment.jsx
@@ -49,7 +49,7 @@ const GradingScaleSegment = ({
             disabled={idx === gradingSegments.length}
           />
         )}
-        <span className="grading-scale-segment-content-number m-0">
+        <span data-testid="grading-scale-segment-number" className="grading-scale-segment-content-number m-0">
           {gradingSegments[idx === 0 ? 0 : idx - 1]?.previous} - {value === 100 ? value : value - 1}
         </span>
       </div>


### PR DESCRIPTION
When the user tries to add more than 5 grades then the save pop that appears near the footer doesn't appear.

**JIRA tickets**: Private ref: [BB-9232](https://tasks.opencraft.com/browse/BB-9232)

**Testing instructions**:

1. Set the theming as mentioned in https://github.com/open-craft/frontend-app-authoring/pull/72
2. Once that is done go to the grade page and see if you have more than 5 grades available.
3. If not you need to change settings under edx-platform

```diff
diff --git a/cms/envs/common.py b/cms/envs/common.py
index 7918624841..c4bea76847 100644
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2442,7 +2442,7 @@ POLICY_CHANGE_TASK_RATE_LIMIT = '900/h'
 # .. setting_warning: The DEFAULT_GRADE_DESIGNATIONS list must have more than one designation,
 #     or else ['A', 'B', 'C', 'D'] will be used as the default grade designations. Also, only the first
 #     11 grade designations are used by the UI, so it's advisable to restrict the list to 11 items.
-DEFAULT_GRADE_DESIGNATIONS = ['A', 'B', 'C', 'D']
+DEFAULT_GRADE_DESIGNATIONS = ['A-', 'B+', 'B-', 'C+', 'C-', 'D+']
 
```
4. This should reload the LMS and if doesn't then you need to  restart LMS by `tutor dev restart lms`
5. Hard refresh the page and try adding the grade and save the grades. More than 4 possibly.
6. Now try adding the grade again and you should see that the save grade box will not appear.
7. Now change to `farhaan-grading-pop` and restart the course-authoring app `tutor dev restart course-authoring`
8. Try the above steps again and you should see it working.