### PR TITLE
fix: dropdown menus show over the sidebar

### DIFF
--- a/src/library-authoring/LibraryAuthoringPage.scss
+++ b/src/library-authoring/LibraryAuthoringPage.scss
@@ -12,13 +12,17 @@
 }
 
 .library-authoring-sidebar {
-  z-index: 1001; // to appear over header
+  z-index: 1000; // same as header
   flex: 450px 0 0;
   position: sticky;
   top: 0;
   right: 0;
   height: 100vh;
   overflow-y: auto;
+}
+
+.dropdown-menu {
+  z-index: 1001; // over the sidebar
 }
 
 // Reduce breadcrumb bottom margin


### PR DESCRIPTION
Moved the sidebar to the same z-index as the header, because layout dictates that the sidebar sits above the header anyway. So could move the dropdown menus up to above the sidebar without using a silly z-index.

![Screenshot 2024-10-25 130436](https://github.com/user-attachments/assets/56a0212d-6feb-4a1d-a47b-87736870c91c)

Expand button is still ok:

![image](https://github.com/user-attachments/assets/f4099604-7ea3-4791-b222-819514499833)

Builds on https://github.com/openedx/frontend-app-authoring/pull/1438

### Testing instructions

1. Go to library home of a library
1. Click on a component card to open the component info sidebar
1. Click on the ... menu on the component card
2. Verify that the dropdown menu appears over the sidebar
3. Verify that the sidebar dropdown menu still appears over the Expand button


