### PR TITLE
fix: URL for Pages & Resources

### DIFF
--- a/src/header/hooks.js
+++ b/src/header/hooks.js
@@ -19,7 +19,7 @@ export const useContentMenuItems = courseId => {
       title: intl.formatMessage(messages['header.links.updates']),
     },
     {
-      href: getPagePath(courseId, 'true', 'tabs'),
+      href: `/course/${courseId}/pages-and-resources`,
       title: intl.formatMessage(messages['header.links.pages']),
     },
     {


### PR DESCRIPTION
## Description

Fixes the link to "Pages & Resources" in the authoring MFE.

## Other information

[BB-9542](https://tasks.opencraft.com/browse/BB-9542)