### PR TITLE
fix: request only the active courses for home

### DIFF
--- a/src/studio-home/hooks.jsx
+++ b/src/studio-home/hooks.jsx
@@ -43,7 +43,7 @@ const useStudioHome = () => {
   useEffect(() => {
     if (isPaginated) {
       const firstPage = 1;
-      dispatch(fetchStudioHomeData(location.search ?? '', false, { page: firstPage, order: 'display_name' }, true));
+      dispatch(fetchStudioHomeData(location.search ?? '', false, { page: firstPage, order: 'display_name', active_only: true }, true));
     }
   }, []);
 


### PR DESCRIPTION
By default the list of courses on the home page are limited to "active" courses only. However, the
API query wasn't filtering for active courses, leading to a bug showing archived courses in the list. This commit adds the active_only filter for the first load.

Internal-ref: https://tasks.opencraft.com/browse/BB-9718


## Testing instructions

1. Setup a Tutor env with [asu-moe-release/sumac](https://github.com/open-craft/frontend-app-authoring/tree/asu-moe-release/sumac) branch of the Authoring MFE (bind-monted and dev)
2. This will require the following Tutor Plugin to load the correct styles
```py
from tutor import hooks

hooks.Filters.ENV_PATCHES.add_item(("mfe-lms-common-settings", """
MFE_CONFIG["PARAGON_THEME_URLS"] = {
   "core": {
     "urls": {
       "brandOverride": "https://eshe-themes-static-files.s3.me-south-1.amazonaws.com/css/core.min.css",
       "default": "https://cdn.jsdelivr.net/npm/@openedx/paragon@23.4/dist/core.min.css"
     }
   },
   "defaults": {
     "light": "light"
   },
   "variants": {
     "light": {
       "dark": False,
       "default": True,
       "urls": {
         "brandOverride": "https://eshe-themes-static-files.s3.me-south-1.amazonaws.com/css/default-eshe.min.css",
         "default": "https://cdn.jsdelivr.net/npm/@openedx/paragon@23.4/dist/light.min.css"
       }
     }
   }
}
"""))
```
3. Create a course and set it's starting and ending date in the past (this will make it archived)
4. Go to Studio Home -> http://apps.local.openedx.io:2001/authoring/home
5. Notice that the "Archived" course is showing up in the list despite the filter saying "Active".
6. Switch to the PR branch and refresh the studio home page. Now it SHOULDN"T show the Archived courses anymore. Switch between the different options in the filter (All courses, active, archived) and verify that the results are as expected.

P.S: If you get a "Webpack compiled with warnings" overlay at this point. Just close it. I didn't debug this, probably something to do with runtime-themeing and old Paragon versions.

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/bc08ce88-f9cd-4393-96a2-7d6b108f6934)

### After

![image](https://github.com/user-attachments/assets/75b84924-b795-43fa-aae3-40733d006720)
