### PR TITLE
fix: import header scss file

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -2,7 +2,7 @@
 // @import "~@edx/brand/paragon/variables";
 // @import "~@openedx/paragon/scss/core/core";
 // @import "~@edx/brand/paragon/overrides";
-// @import "~@edx/frontend-component-header/dist/index";
+@import "~@edx/frontend-component-header/dist/index";
 @import "assets/scss/variables";
 @import "assets/scss/form";
 @import "assets/scss/utilities";


### PR DESCRIPTION
## Description

This PR adds import of header component's scss files into authoring MFE which was removed inadvertently earlier.



## Other information

Private Ref : [BB-9698](https://tasks.opencraft.com/browse/BB-9698)