### PR TITLE
fix: Rename optimistic update in children containers

### DIFF
--- a/src/library-authoring/__mocks__/library-search.json
+++ b/src/library-authoring/__mocks__/library-search.json
@@ -494,7 +494,7 @@
           ],
           "created": 1742221203.895054,
           "modified": 1742221203.895054,
-          "usage_key": "lct:Axim:TEST:unit:test-unit-9284e2",
+          "usage_key": "lct:org:lib:unit:test-unit-9a207",
           "block_type": "unit",
           "context_key": "lib:Axim:TEST",
           "org": "Axim",
@@ -512,18 +512,18 @@
             ],
             "created": "1742221203.895054",
             "modified": "1742221203.895054",
-            "usage_key": "lct:Axim:TEST:unit:test-unit-9284e2",
+            "usage_key": "lct:org:lib:unit:test-unit-9a207",
             "block_type": "unit",
             "context_key": "lib:Axim:TEST",
             "org": "Axim",
             "access_id": "15",
             "num_children": "0",
             "published": {
-              "display_name": "Test Unit"
+              "display_name": "Published Test Unit"
             }
           },
           "published": {
-            "display_name": "Test Unit"
+            "display_name": "Published Test Unit"
           }
         }
       ],

--- a/src/library-authoring/component-picker/ComponentPicker.test.tsx
+++ b/src/library-authoring/component-picker/ComponentPicker.test.tsx
@@ -15,6 +15,7 @@ import {
   mockGetCollectionMetadata,
   mockGetContentLibraryV2List,
   mockLibraryBlockMetadata,
+  mockGetContainerMetadata,
 } from '../data/api.mocks';
 
 import { ComponentPicker } from './ComponentPicker';
@@ -41,6 +42,7 @@ mockContentSearchConfig.applyMock();
 mockGetCollectionMetadata.applyMock();
 mockGetContentLibraryV2List.applyMock();
 mockLibraryBlockMetadata.applyMock();
+mockGetContainerMetadata.applyMock();
 
 let postMessageSpy: jest.SpyInstance;
 
@@ -66,7 +68,6 @@ describe('<ComponentPicker />', () => {
     });
 
     // Navigate to the components tab
-    screen.logTestingPlaygroundURL();
     const componentsTab = screen.getByRole('tab', { name: 'Components' });
     fireEvent.click(componentsTab);
     expect(componentsTab).toHaveAttribute('aria-selected', 'true');
@@ -156,10 +157,11 @@ describe('<ComponentPicker />', () => {
     expect(await screen.findByText('Test Library 1')).toBeInTheDocument();
 
     // Click on the unit card to open the sidebar
-    fireEvent.click((await screen.findByText('Test Unit')));
+    fireEvent.click((await screen.findByText('Published Test Unit')));
 
     const sidebar = await screen.findByTestId('library-sidebar');
     expect(sidebar).toBeInTheDocument();
+    await waitFor(() => expect(within(sidebar).getByText('Published Test Unit')).toBeInTheDocument());
   });
 
   it('double clicking a collection should open it', async () => {

--- a/src/library-authoring/containers/ContainerEditableTitle.tsx
+++ b/src/library-authoring/containers/ContainerEditableTitle.tsx
@@ -12,7 +12,8 @@ interface EditableTitleProps {
   textClassName?: string;
   // In some cases, the title is already available, but it's retrieved in a list of containers.
   // In these cases, it's necessary to use this `ContainerEditableTitle` for the optimistic update to work.
-  // By using `placeHolderText`, we can give the illusion that the data has already been loaded before using the real data.
+  // By using `placeHolderText`, we can give the illusion that the data
+  // has already been loaded before using the real data.
   placeHolderText?: string;
 }
 
@@ -25,10 +26,6 @@ export const ContainerEditableTitle = ({
   const intl = useIntl();
 
   const { readOnly: libReadOnly, showOnlyPublished } = useLibraryContext();
-
-  if (!readOnly) {
-    readOnly = libReadOnly;
-  }
 
   const { data: container, isLoading } = useContainer(containerId);
 
@@ -52,14 +49,14 @@ export const ContainerEditableTitle = ({
   } else if (isLoading || !container) {
     textTitle = '';
   } else {
-    textTitle = showOnlyPublished ? (container.publishedDisplayName ?? container.displayName) : container.displayName
+    textTitle = showOnlyPublished ? (container.publishedDisplayName ?? container.displayName) : container.displayName;
   }
 
   return (
     <InplaceTextEditor
       onSave={handleSaveDisplayName}
       text={textTitle}
-      readOnly={readOnly}
+      readOnly={readOnly || libReadOnly}
       textClassName={textClassName}
     />
   );

--- a/src/library-authoring/containers/ContainerEditableTitle.tsx
+++ b/src/library-authoring/containers/ContainerEditableTitle.tsx
@@ -8,12 +8,13 @@ import messages from './messages';
 
 interface EditableTitleProps {
   containerId: string;
+  textClassName?: string;
 }
 
-export const ContainerEditableTitle = ({ containerId }: EditableTitleProps) => {
+export const ContainerEditableTitle = ({ containerId, textClassName }: EditableTitleProps) => {
   const intl = useIntl();
 
-  const { readOnly } = useLibraryContext();
+  const { readOnly, showOnlyPublished } = useLibraryContext();
 
   const { data: container } = useContainer(containerId);
 
@@ -39,8 +40,9 @@ export const ContainerEditableTitle = ({ containerId }: EditableTitleProps) => {
   return (
     <InplaceTextEditor
       onSave={handleSaveDisplayName}
-      text={container.displayName}
+      text={showOnlyPublished ? (container.publishedDisplayName ?? container.displayName) : container.displayName}
       readOnly={readOnly}
+      textClassName={textClassName}
     />
   );
 };

--- a/src/library-authoring/containers/ContainerInfoHeader.tsx
+++ b/src/library-authoring/containers/ContainerInfoHeader.tsx
@@ -1,17 +1,7 @@
-import { useContext } from 'react';
-import { useIntl } from '@edx/frontend-platform/i18n';
-
-import { InplaceTextEditor } from '../../generic/inplace-text-editor';
-import { ToastContext } from '../../generic/toast-context';
-import { useLibraryContext } from '../common/context/LibraryContext';
 import { useSidebarContext } from '../common/context/SidebarContext';
-import { useContainer, useUpdateContainer } from '../data/apiHooks';
-import messages from './messages';
+import { ContainerEditableTitle } from './ContainerEditableTitle';
 
 const ContainerInfoHeader = () => {
-  const intl = useIntl();
-
-  const { readOnly } = useLibraryContext();
   const { sidebarItemInfo } = useSidebarContext();
 
   const containerId = sidebarItemInfo?.id;
@@ -20,31 +10,9 @@ const ContainerInfoHeader = () => {
     throw new Error('containerId is required');
   }
 
-  const { data: container } = useContainer(containerId);
-
-  const updateMutation = useUpdateContainer(containerId);
-  const { showToast } = useContext(ToastContext);
-
-  const handleSaveDisplayName = async (newDisplayName: string) => {
-    try {
-      await updateMutation.mutateAsync({
-        displayName: newDisplayName,
-      });
-      showToast(intl.formatMessage(messages.updateContainerSuccessMsg));
-    } catch (err) {
-      showToast(intl.formatMessage(messages.updateContainerErrorMsg));
-    }
-  };
-
-  if (!container) {
-    return null;
-  }
-
   return (
-    <InplaceTextEditor
-      onSave={handleSaveDisplayName}
-      text={container.displayName}
-      readOnly={readOnly}
+    <ContainerEditableTitle
+      containerId={containerId}
       textClassName="font-weight-bold m-1.5"
     />
   );

--- a/src/library-authoring/data/api.mocks.ts
+++ b/src/library-authoring/data/api.mocks.ts
@@ -493,6 +493,17 @@ export async function mockGetContainerMetadata(containerId: string): Promise<api
     case mockGetContainerMetadata.subsectionIdEmpty:
       return Promise.resolve(mockGetContainerMetadata.subsectionData);
     default:
+      if (containerId.startsWith('lct:org1:Demo_course_generated:')) {
+        const lastPart = containerId.split(':').pop();
+        if (lastPart) {
+          const [name, idx] = lastPart.split('-');
+          return Promise.resolve({
+            ...mockGetContainerMetadata.containerData,
+            displayName: `${name} block ${idx}`,
+            publishedDisplayName: `${name} block published ${idx}`,
+          });
+        }
+      }
       return Promise.resolve(mockGetContainerMetadata.containerData);
   }
 }
@@ -574,19 +585,22 @@ export async function mockGetContainerChildren(containerId: string): Promise<api
   }
   let blockType = 'html';
   let name = 'text';
+  let typeNamespace = 'lb';
   if (containerId.includes('subsection')) {
     blockType = 'unit';
     name = blockType;
+    typeNamespace = 'lct';
   } else if (containerId.includes('section')) {
     blockType = 'subsection';
     name = blockType;
+    typeNamespace = 'lct';
   }
   return Promise.resolve(
     Array(numChildren).fill(mockGetContainerChildren.childTemplate).map((child, idx) => (
       {
         ...child,
         // Generate a unique ID for each child block to avoid "duplicate key" errors in tests
-        id: `lb:org1:Demo_course:${blockType}:${name}-${idx}`,
+        id: `${typeNamespace}:org1:Demo_course_generated:${blockType}:${name}-${idx}`,
         displayName: `${name} block ${idx}`,
         publishedDisplayName: `${name} block published ${idx}`,
       }

--- a/src/library-authoring/data/api.mocks.ts
+++ b/src/library-authoring/data/api.mocks.ts
@@ -283,7 +283,7 @@ mockXBlockFields.dataHtml = {
   metadata: { displayName: 'Introduction to Testing' },
 } satisfies api.XBlockFields;
 // Mock of another "regular" HTML (Text) block:
-mockXBlockFields.usageKey0 = 'lb:org1:Demo_course:html:text-0';
+mockXBlockFields.usageKey0 = 'lb:org1:Demo_course_generated:html:text-0';
 mockXBlockFields.dataHtml0 = {
   displayName: 'text block 0',
   data: '<p>This is a text component which uses <strong>HTML</strong>.</p>',

--- a/src/library-authoring/data/api.mocks.ts
+++ b/src/library-authoring/data/api.mocks.ts
@@ -513,7 +513,7 @@ mockGetContainerMetadata.containerData = {
   id: 'lct:org:lib:unit:test-unit-9a2072',
   containerType: ContainerType.Unit,
   displayName: 'Test Unit',
-  publishedDisplayName: 'Test Unit',
+  publishedDisplayName: 'Published Test Unit',
   created: '2024-09-19T10:00:00Z',
   createdBy: 'test_author',
   lastPublished: '2024-09-20T10:00:00Z',

--- a/src/library-authoring/data/apiHooks.test.tsx
+++ b/src/library-authoring/data/apiHooks.test.tsx
@@ -311,6 +311,26 @@ describe('library api hooks', () => {
     });
   });
 
+  it('should invalidate subsection when added to section', async () => {
+    const spy = jest.spyOn(queryClient, 'invalidateQueries');
+    const subsectionId1 = 'lct:org:lib:subsection:1';
+    const subsectionId2 = 'lct:org:lib:subsection:2';
+    const sectionId = 'lct:org:lib:section:1';
+    const url = getLibraryContainerChildrenApiUrl(sectionId);
+
+    axiosMock.onPost(url).reply(200);
+
+    const { result } = renderHook(() => useAddItemsToContainer(sectionId), { wrapper });
+
+    await result.current.mutateAsync([subsectionId1, subsectionId2]);
+
+    expect(axiosMock.history.post[0].url).toEqual(url);
+
+    // Two call for `containerChildren` and library predicate
+    // and two more calls to invalidate the subsections.
+    expect(spy).toHaveBeenCalledTimes(4);
+  });
+
   describe('publishContainer', () => {
     it('should publish a container', async () => {
       const containerId = 'lct:org:lib:unit:1';

--- a/src/library-authoring/data/apiHooks.ts
+++ b/src/library-authoring/data/apiHooks.ts
@@ -8,11 +8,12 @@ import {
   replaceEqualDeep,
 } from '@tanstack/react-query';
 import { useCallback } from 'react';
+import { type MeiliSearch } from 'meilisearch';
 
-import { getLibraryId } from '../../generic/key-utils';
+import { getBlockType, getLibraryId } from '../../generic/key-utils';
 import * as api from './api';
 import { VersionSpec } from '../LibraryBlock';
-import { useContentSearchConnection, useContentSearchResults } from '../../search-manager';
+import { useContentSearchConnection, useContentSearchResults, buildSearchQueryKey } from '../../search-manager';
 
 export const libraryQueryPredicate = (query: Query, libraryId: string): boolean => {
   // Invalidate all content queries related to this library.
@@ -698,10 +699,33 @@ export const useContainerChildren = (containerId?: string, published: boolean = 
 );
 
 /**
+ * If you work with `useContentFromSearchIndex`, you can use this
+ * function to get the query key, usually to invalidate the query.
+ */
+const getSearchQueryKeyFromContent = (
+  contentIds: string[],
+  client?: MeiliSearch,
+  indexName?: string,
+) => (
+  buildSearchQueryKey({
+    client,
+    indexName,
+    extraFilter: [`usage_key IN ["${contentIds.join('","')}"]`],
+    searchKeywords: '',
+    blockTypesFilter: [],
+    problemTypesFilter: [],
+    publishStatusFilter: [],
+    tagsFilter: [],
+    sort: [],
+  })
+);
+
+/**
  * Use this mutation to add items to a container
  */
 export const useAddItemsToContainer = (containerId?: string) => {
   const queryClient = useQueryClient();
+  const { client, indexName } = useContentSearchConnection();
   return useMutation({
     mutationFn: async (itemIds: string[]) => {
       // istanbul ignore if: this should never happen
@@ -710,7 +734,7 @@ export const useAddItemsToContainer = (containerId?: string) => {
       }
       return api.addComponentsToContainer(containerId, itemIds);
     },
-    onSettled: () => {
+    onSettled: (_data, _error, variables) => {
       // istanbul ignore if: this should never happen
       if (!containerId) {
         return;
@@ -720,6 +744,17 @@ export const useAddItemsToContainer = (containerId?: string) => {
       const libraryId = getLibraryId(containerId);
       queryClient.invalidateQueries({ queryKey: libraryAuthoringQueryKeys.containerChildren(containerId) });
       queryClient.invalidateQueries({ predicate: (query) => libraryQueryPredicate(query, libraryId) });
+
+      const containerType = getBlockType(containerId);
+      if (containerType === 'section') {
+        // We invalidate the search query of the each itemId if the container is a section.
+        // This because the subsection page calls this query individually.
+        variables.forEach((itemId) => {
+          queryClient.invalidateQueries({
+            queryKey: getSearchQueryKeyFromContent([itemId], client, indexName),
+          });
+        });
+      }
     },
   });
 };

--- a/src/library-authoring/section-subsections/LibraryContainerChildren.tsx
+++ b/src/library-authoring/section-subsections/LibraryContainerChildren.tsx
@@ -42,11 +42,13 @@ const ContainerRow = ({ container, readOnly }: ContainerRowProps) => {
 
   return (
     <>
-      <ContainerEditableTitle 
+      <ContainerEditableTitle
         containerId={container.originalId}
         readOnly={readOnly || showOnlyPublished}
         textClassName="font-weight-bold small"
-        placeHolderText={showOnlyPublished ? (container.publishedDisplayName ?? container.displayName) : container.displayName}
+        placeHolderText={
+          showOnlyPublished ? (container.publishedDisplayName ?? container.displayName) : container.displayName
+        }
       />
       <ActionRow.Spacer />
       <Stack

--- a/src/library-authoring/section-subsections/LibraryContainerChildren.tsx
+++ b/src/library-authoring/section-subsections/LibraryContainerChildren.tsx
@@ -12,13 +12,11 @@ import ErrorAlert from '../../generic/alert-error';
 import { useLibraryContext } from '../common/context/LibraryContext';
 import {
   useContainerChildren,
-  useUpdateContainer,
   useUpdateContainerChildren,
 } from '../data/apiHooks';
 import { messages, subsectionMessages, sectionMessages } from './messages';
-import containerMessages from '../containers/messages';
+import { ContainerEditableTitle } from '../containers';
 import { Container } from '../data/api';
-import { InplaceTextEditor } from '../../generic/inplace-text-editor';
 import { ToastContext } from '../../generic/toast-context';
 import TagCount from '../../generic/tag-count';
 import { ContainerMenu } from '../components/ContainerCard';
@@ -40,29 +38,15 @@ interface ContainerRowProps extends LibraryContainerChildrenProps {
 }
 
 const ContainerRow = ({ container, readOnly }: ContainerRowProps) => {
-  const intl = useIntl();
-  const { showToast } = useContext(ToastContext);
-  const updateMutation = useUpdateContainer(container.originalId);
   const { showOnlyPublished } = useLibraryContext();
-
-  const handleSaveDisplayName = async (newDisplayName: string) => {
-    try {
-      await updateMutation.mutateAsync({
-        displayName: newDisplayName,
-      });
-      showToast(intl.formatMessage(containerMessages.updateContainerSuccessMsg));
-    } catch (err) {
-      showToast(intl.formatMessage(containerMessages.updateContainerErrorMsg));
-    }
-  };
 
   return (
     <>
-      <InplaceTextEditor
-        onSave={handleSaveDisplayName}
-        text={showOnlyPublished ? (container.publishedDisplayName ?? container.displayName) : container.displayName}
-        textClassName="font-weight-bold small"
+      <ContainerEditableTitle 
+        containerId={container.originalId}
         readOnly={readOnly || showOnlyPublished}
+        textClassName="font-weight-bold small"
+        placeHolderText={showOnlyPublished ? (container.publishedDisplayName ?? container.displayName) : container.displayName}
       />
       <ActionRow.Spacer />
       <Stack

--- a/src/library-authoring/section-subsections/LibrarySectionSubsectionPage.test.tsx
+++ b/src/library-authoring/section-subsections/LibrarySectionSubsectionPage.test.tsx
@@ -104,6 +104,10 @@ describe('<LibrarySectionPage / LibrarySubsectionPage />', () => {
     const childType = cType === ContainerType.Section
       ? ContainerType.Subsection
       : ContainerType.Unit;
+    let typeNamespace = 'lct';
+    if (cType === ContainerType.Unit) {
+      typeNamespace = 'lb';
+    }
     it(`shows the spinner before the query is complete in ${cType} page`, async () => {
       // This mock will never return data about the collection (it loads forever):
       const cId = cType === ContainerType.Section
@@ -253,7 +257,7 @@ describe('<LibrarySectionPage / LibrarySubsectionPage />', () => {
     });
 
     it(`should rename child by clicking edit icon besides name in ${cType} page`, async () => {
-      const url = getLibraryContainerApiUrl(`lb:org1:Demo_course:${childType}:${childType}-0`);
+      const url = getLibraryContainerApiUrl(`${typeNamespace}:org1:Demo_course_generated:${childType}:${childType}-0`);
       axiosMock.onPatch(url).reply(200);
       renderLibrarySectionPage(undefined, undefined, cType);
 
@@ -285,7 +289,7 @@ describe('<LibrarySectionPage / LibrarySubsectionPage />', () => {
     });
 
     it(`should show error while updating child name in ${cType} page`, async () => {
-      const url = getLibraryContainerApiUrl(`lb:org1:Demo_course:${childType}:${childType}-0`);
+      const url = getLibraryContainerApiUrl(`${typeNamespace}:org1:Demo_course_generated:${childType}:${childType}-0`);
       axiosMock.onPatch(url).reply(400);
       renderLibrarySectionPage(undefined, undefined, cType);
 
@@ -326,7 +330,7 @@ describe('<LibrarySectionPage / LibrarySubsectionPage />', () => {
         .onPatch(getLibraryContainerChildrenApiUrl(cId))
         .reply(200);
       verticalSortableListCollisionDetection.mockReturnValue([{
-        id: `lb:org1:Demo_course:${childType}:${childType}-1----1`,
+        id: `${typeNamespace}:org1:Demo_course_generated:${childType}:${childType}-1----1`,
       }]);
       await act(async () => {
         fireEvent.keyDown(firstDragHandle, { code: 'Space' });
@@ -344,7 +348,9 @@ describe('<LibrarySectionPage / LibrarySubsectionPage />', () => {
       axiosMock
         .onPatch(getLibraryContainerChildrenApiUrl(cId))
         .reply(200);
-      verticalSortableListCollisionDetection.mockReturnValue([{ id: `lb:org1:Demo_course:${childType}:${childType}-1----1` }]);
+      verticalSortableListCollisionDetection.mockReturnValue([{
+        id: `${typeNamespace}:org1:Demo_course_generated:${childType}:${childType}-1----1`,
+      }]);
       await act(async () => {
         fireEvent.keyDown(firstDragHandle, { code: 'Space' });
       });
@@ -361,7 +367,9 @@ describe('<LibrarySectionPage / LibrarySubsectionPage />', () => {
       axiosMock
         .onPatch(getLibraryContainerChildrenApiUrl(cId))
         .reply(500);
-      verticalSortableListCollisionDetection.mockReturnValue([{ id: `lb:org1:Demo_course:${childType}:${childType}-1----1` }]);
+      verticalSortableListCollisionDetection.mockReturnValue([{
+        id: `${typeNamespace}:org1:Demo_course_generated:${childType}:${childType}-1----1`,
+      }]);
       await act(async () => {
         fireEvent.keyDown(firstDragHandle, { code: 'Space' });
       });
@@ -374,7 +382,7 @@ describe('<LibrarySectionPage / LibrarySubsectionPage />', () => {
       const child = await screen.findByText(`${childType} block 0`);
       // trigger double click
       userEvent.click(child.parentElement!, undefined, { clickCount: 2 });
-      expect((await screen.findAllByText(new RegExp(`Test ${childType}`, 'i')))[0]).toBeInTheDocument();
+      expect((await screen.findAllByText(new RegExp(`${childType} block 0`, 'i')))[0]).toBeInTheDocument();
       expect(await screen.findByRole('button', { name: new RegExp(`${childType} Info`, 'i') })).toBeInTheDocument();
     });
   });

--- a/src/library-authoring/units/LibraryUnitPage.test.tsx
+++ b/src/library-authoring/units/LibraryUnitPage.test.tsx
@@ -211,7 +211,7 @@ describe('<LibraryUnitPage />', () => {
   });
 
   it('should rename component while clicking on name', async () => {
-    const url = getXBlockFieldsApiUrl('lb:org1:Demo_course:html:text-0');
+    const url = getXBlockFieldsApiUrl('lb:org1:Demo_course_generated:html:text-0');
     axiosMock.onPost(url).reply(200);
     renderLibraryUnitPage();
 
@@ -245,7 +245,7 @@ describe('<LibraryUnitPage />', () => {
   });
 
   it('should show error while updating component name', async () => {
-    const url = getXBlockFieldsApiUrl('lb:org1:Demo_course:html:text-0');
+    const url = getXBlockFieldsApiUrl('lb:org1:Demo_course_generated:html:text-0');
     axiosMock.onPost(url).reply(400);
     renderLibraryUnitPage();
 
@@ -284,7 +284,9 @@ describe('<LibraryUnitPage />', () => {
     axiosMock
       .onPatch(getLibraryContainerChildrenApiUrl(mockGetContainerMetadata.unitId))
       .reply(200);
-    verticalSortableListCollisionDetection.mockReturnValue([{ id: 'lb:org1:Demo_course:html:text-1----1' }]);
+    verticalSortableListCollisionDetection.mockReturnValue([{
+      id: 'lb:org1:Demo_course_generated:html:text-1----1',
+    }]);
     await act(async () => {
       fireEvent.keyDown(firstDragHandle, { code: 'Space' });
     });
@@ -298,7 +300,9 @@ describe('<LibraryUnitPage />', () => {
     axiosMock
       .onPatch(getLibraryContainerChildrenApiUrl(mockGetContainerMetadata.unitId))
       .reply(200);
-    verticalSortableListCollisionDetection.mockReturnValue([{ id: 'lb:org1:Demo_course:html:text-1----1' }]);
+    verticalSortableListCollisionDetection.mockReturnValue([{
+      id: 'lb:org1:Demo_course_generated:html:text-1----1',
+    }]);
     await act(async () => {
       fireEvent.keyDown(firstDragHandle, { code: 'Space' });
     });
@@ -312,7 +316,9 @@ describe('<LibraryUnitPage />', () => {
     axiosMock
       .onPatch(getLibraryContainerChildrenApiUrl(mockGetContainerMetadata.unitId))
       .reply(500);
-    verticalSortableListCollisionDetection.mockReturnValue([{ id: 'lb:org1:Demo_course:html:text-1----1' }]);
+    verticalSortableListCollisionDetection.mockReturnValue([{
+      id: 'lb:org1:Demo_course_generated:html:text-1----1',
+    }]);
     await act(async () => {
       fireEvent.keyDown(firstDragHandle, { code: 'Space' });
     });

--- a/src/search-manager/data/apiHooks.ts
+++ b/src/search-manager/data/apiHooks.ts
@@ -44,6 +44,43 @@ export const useContentSearchConnection = (): {
   return { client, indexName, hasConnectionError };
 };
 
+export const buildSearchQueryKey = ({
+  client,
+  indexName,
+  extraFilter,
+  searchKeywords,
+  blockTypesFilter,
+  problemTypesFilter,
+  publishStatusFilter,
+  tagsFilter,
+  sort,
+}: {
+  client?: MeiliSearch;
+  indexName?: string;
+  extraFilter?: Filter;
+  searchKeywords: string;
+  blockTypesFilter: string[];
+  problemTypesFilter: string[];
+  publishStatusFilter: PublishStatus[];
+  tagsFilter: string[];
+  sort: SearchSortOption[];
+}) => (
+  [
+    'content_search',
+    'results',
+    client?.config.apiKey,
+    client?.config.host,
+    indexName,
+    extraFilter,
+    searchKeywords,
+    blockTypesFilter,
+    problemTypesFilter,
+    publishStatusFilter,
+    tagsFilter,
+    sort,
+  ]
+);
+
 /**
  * Get the results of a search
  */
@@ -87,11 +124,8 @@ export const useContentSearchResults = ({
 }) => {
   const query = useInfiniteQuery({
     enabled: enabled && client !== undefined && indexName !== undefined,
-    queryKey: [
-      'content_search',
-      'results',
-      client?.config.apiKey,
-      client?.config.host,
+    queryKey: buildSearchQueryKey({
+      client,
       indexName,
       extraFilter,
       searchKeywords,
@@ -100,7 +134,7 @@ export const useContentSearchResults = ({
       publishStatusFilter,
       tagsFilter,
       sort,
-    ],
+    }),
     queryFn: ({ pageParam = 0 }) => {
       // istanbul ignore if: this should never happen
       if (client === undefined || indexName === undefined) {

--- a/src/search-manager/index.ts
+++ b/src/search-manager/index.ts
@@ -9,7 +9,12 @@ export { default as SearchKeywordsField } from './SearchKeywordsField';
 export { default as SearchSortWidget } from './SearchSortWidget';
 export { default as Stats } from './Stats';
 export { HIGHLIGHT_PRE_TAG, HIGHLIGHT_POST_TAG, PublishStatus } from './data/api';
-export { useContentSearchConnection, useContentSearchResults, useGetBlockTypes } from './data/apiHooks';
+export {
+  useContentSearchConnection,
+  useContentSearchResults,
+  useGetBlockTypes,
+  buildSearchQueryKey,
+} from './data/apiHooks';
 export { TypesFilterData } from './hooks';
 
 export type {

--- a/src/studio-home/data/api.js
+++ b/src/studio-home/data/api.js
@@ -24,6 +24,7 @@ export async function getStudioHomeCourses(search) {
 /**
  * Get's studio home courses.
  * @param {string} search - Query string parameters for filtering the courses.
+ *   TODO: this should be an object with a list of allowed keys and values; not a string.
  * @param {object} customParams - Additional custom parameters for the API request.
  * @returns {Promise<Object>} - A Promise that resolves to the response data containing the studio home courses.
  * Note: We are changing /api/contentstore/v1 to /api/contentstore/v2 due to upcoming breaking changes.

--- a/src/studio-home/data/thunks.js
+++ b/src/studio-home/data/thunks.js
@@ -14,6 +14,13 @@ import {
   fetchCourseDataSuccessV2,
 } from './slice';
 
+/**
+ * Load both the "Studio Home" data and the course list. Store it in the Redux state.
+ *
+ * TODO: this should be replaced with two separate React Query hooks - one that calls
+ * useQuery() to load the "studio home" data, and another that calls useQuery() to
+ * load the course list.
+ */
 function fetchStudioHomeData(
   search,
   hasHomeData,


### PR DESCRIPTION
## Description

- When you update the title of a unit/subsection in the subsection/section page, the text returns to the previous value for a while. This PR fix that issue
- Which edX user roles will this change impact? "Course Author.

## Supporting information

- This issue was encountered while working on https://github.com/openedx/frontend-app-authoring/issues/1971
- Internal ticket: [FAL-4165](https://tasks.opencraft.com/browse/FAL-4165)

## Testing instructions

- Go to the library home of a library
- Create one unit, one subsection and one section.
- Add the unit to the subsection.
- Add the subsection to the section.
- On the section page, rename the subsection, verify that the optimistic update works.
- On the subsection page, rename the unit, verify that the optimistic update works.


## Other information

- Fixing this issue results in an increase in requests, but the user  is not affected for the use of [placeHolderText](https://github.com/open-craft/frontend-app-authoring/pull/90/files#diff-1ae8b7fff8780b37c89ac8669f61267d687fa66f56a6640bf5ef3fe3e4c7f680R16)