### PR TITLE
fix: (backport) broken Course Overview editor on Schedule & Details page (#2599)

### DIFF
--- a/src/schedule-and-details/index.jsx
+++ b/src/schedule-and-details/index.jsx
@@ -116,7 +116,6 @@ const ScheduleAndDetails = ({ intl, courseId }) => {
     license,
     language,
     subtitle,
-    overview,
     duration,
     selfPaced,
     startDate,
@@ -127,7 +126,6 @@ const ScheduleAndDetails = ({ intl, courseId }) => {
     instructorInfo,
     enrollmentStart,
     shortDescription,
-    aboutSidebarHtml,
     preRequisiteCourses,
     entranceExamEnabled,
     courseImageAssetPath,
@@ -139,6 +137,12 @@ const ScheduleAndDetails = ({ intl, courseId }) => {
   } = editedValues;
 
   useScrollToHashElement({ isLoading });
+  // No need to get overview and aboutSidebarHtml from editedValues
+  // As updating them re-renders TinyMCE
+  // Which causes issues with TinyMCE editor cursor position
+  // https://www.tiny.cloud/docs/tinymce/5/react/#initialvalue
+  const { overview: initialOverview } = courseDetails || {};
+  const { aboutSidebarHtml: initialAboutSidebarHtml } = courseDetails || {};
 
   if (isLoading) {
     // eslint-disable-next-line react/jsx-no-useless-fragment
@@ -276,12 +280,12 @@ const ScheduleAndDetails = ({ intl, courseId }) => {
                   )}
                   <IntroducingSection
                     title={title}
-                    overview={overview}
+                    overview={initialOverview}
                     duration={duration}
                     subtitle={subtitle}
                     introVideo={introVideo}
                     description={description}
-                    aboutSidebarHtml={aboutSidebarHtml}
+                    aboutSidebarHtml={initialAboutSidebarHtml}
                     shortDescription={shortDescription}
                     aboutPageEditable={aboutPageEditable}
                     sidebarHtmlEnabled={sidebarHtmlEnabled}


### PR DESCRIPTION
## Description

This merge request backports a fix for a bug that causes the description editor on the course details page to constantly shove the cursor to the beginning of the field.

## Supporting information

https://github.com/openedx/frontend-app-authoring/pull/2599

## Testing instructions

1. Using tutor 20.x, set up a local installation.
2. Clone this repository and check out the `opencraft-release/teak` branch to get the broken version
3. Mount using `tutor mounts add /path/to/frontend-app-authoring`
4. `tutor dev launch`
5. Check the Scheduling and Details page. Edit using the WYSIWYG editor and notice that the cursor jumps to the beginning each keystroke.
6. In the repository, check out this branch. Refresh the Scheduling and Details page.
7. Observe the cursor behaving correctly.